### PR TITLE
Allow primary key to be specified for relationship

### DIFF
--- a/pgsync/constants.py
+++ b/pgsync/constants.py
@@ -38,6 +38,7 @@ RELATIONSHIP_ATTRIBUTES = [
     "through_tables",
     "type",
     "variant",
+    "primary_key",
 ]
 
 # Relationship foreign keys

--- a/pgsync/node.py
+++ b/pgsync/node.py
@@ -64,6 +64,7 @@ class Relationship:
         self.through_tables: List[str] = self.relationship.get(
             "through_tables", []
         )
+        self.primary_key: List[str] = self.relationship.get("primary_key", [])
         self.through_nodes: List[Node] = []
 
         if not set(self.relationship.keys()).issubset(
@@ -97,7 +98,7 @@ class Relationship:
 
     def __str__(self):
         return (
-            f"relationship: {self.variant}.{self.type}:{self.through_tables}"
+            f"relationship: {self.variant}.{self.type}:{self.through_tables}.{self.primary_key}"
         )
 
 
@@ -149,7 +150,7 @@ class Node(object):
                     table=through_table,
                     schema=self.schema,
                     parent=self,
-                    primary_key=[],
+                    primary_key=self.relationship.primary_key,
                 )
             )
 


### PR DESCRIPTION
Workaround for Prisma-managed implicit through tables that have no primary key defined

- https://github.com/prisma/prisma/issues/11110