### PR TITLE
Support querying from replica DB

### DIFF
--- a/pgsync/settings.py
+++ b/pgsync/settings.py
@@ -116,6 +116,7 @@ ELASTICSEARCH_VERIFY_CERTS = env.bool(
 
 # Postgres:
 PG_HOST = env.str("PG_HOST", default="localhost")
+PG_RO_HOST = env.str("PG_RO_HOST", default=PG_HOST)
 PG_PASSWORD = env.str("PG_PASSWORD", default=None)
 PG_PORT = env.int("PG_PORT", default=5432)
 PG_SSLMODE = env.str("PG_SSLMODE", default=None)

--- a/pgsync/sync.py
+++ b/pgsync/sync.py
@@ -10,7 +10,10 @@ import re
 import select
 import sys
 import time
+import warnings
 from collections import defaultdict
+
+from sqlalchemy.exc import SAWarning
 from typing import AnyStr, Dict, Generator, List, Optional, Set
 
 import click
@@ -67,6 +70,7 @@ from .utils import (
 )
 
 logger = logging.getLogger(__name__)
+warnings.filterwarnings("ignore", category=SAWarning, module="pgsync.base")
 
 
 class Sync(Base):


### PR DESCRIPTION
Experimental, as we’ll get replication slot changes from the master and then attempt to read from the replica, which may not have the physical replication changes copied over from the WAL yet.

Also silenced annoying warnings about expression-based indices:
```
/app/pgsync/base.py:179: SAWarning: Skipped unsupported reflection of expression-based index some_value_unique
```